### PR TITLE
Use AWS ec2metadata service for cloud instances

### DIFF
--- a/cloudflare_ddns.py
+++ b/cloudflare_ddns.py
@@ -69,7 +69,7 @@ def main():
       except:
         msg = "Failed to query AWS ec2metadata for public IP"
         log(now, 'critical', '(no conf)', '(no conf)', msg)
-    raise Exception(msg)
+        raise Exception(msg)
     else:
       public_ip = requests.get("http://ipv4.icanhazip.com/").text.strip()
 

--- a/config.yaml.template
+++ b/config.yaml.template
@@ -25,3 +25,7 @@ cf_service_mode: 1
 # there's an error.  If set to 'false', prints a message every time even if
 # the record didn't change.
 quiet: 'false'
+
+# If set to true then we call the ec2metadata service for the instance
+# public ip address rather than an external service.
+aws_use_ec2metadata: false


### PR DESCRIPTION
Ahoy,

I picked this up and added support for using the AWS provided external IP resolution via ec2metadata service rather than calling @major 's external service. It's a nice alternative to firing up full blown route53 zones and delegation when all I needed was a single A record to be managed :)

Cheers,

Sam