### PR TITLE
Retrieve public IP using dig the neat way

### DIFF
--- a/cloudflare_ddns.py
+++ b/cloudflare_ddns.py
@@ -81,11 +81,8 @@ def main():
         output, err = p.communicate()
         rc = p.returncode
         public_ip = output.decode().rstrip()
-        print("Dig used");
-        print(public_ip)
     else:
         public_ip = requests.get("https://ipv4.icanhazip.com/").text.strip()
-        print("I can hazip");
         # public_ip = '127.0.0.100'
 
     ### Get zone id for the dns record we want to update

--- a/cloudflare_ddns.py
+++ b/cloudflare_ddns.py
@@ -55,6 +55,7 @@ def main():
     cf_service_mode = config.get('cf_service_mode')
     quiet = 'true' == config.get('quiet')
     aws_use_ec2metadata = config.get('aws_use_ec2metadata')
+    use_dig = config.get('use_dig')
 
     auth_headers = {
         'X-Auth-Key': cf_key,
@@ -75,8 +76,16 @@ def main():
         public_ip = output.rstrip('\n')
       except:
         die("Failed to query AWS ec2metadata for public IP")
+    elif use_dig:
+        p = Popen(["dig", "+short", "myip.opendns.com", "@resolver1.opendns.com"], stdin=PIPE, stdout=PIPE, stderr=PIPE)
+        output, err = p.communicate()
+        rc = p.returncode
+        public_ip = output.decode().rstrip()
+        print("Dig used");
+        print(public_ip)
     else:
         public_ip = requests.get("https://ipv4.icanhazip.com/").text.strip()
+        print("I can hazip");
         # public_ip = '127.0.0.100'
 
     ### Get zone id for the dns record we want to update

--- a/config.yaml.template
+++ b/config.yaml.template
@@ -24,11 +24,15 @@ cf_subdomain: 'YOUR SUBDOMAIN HERE'
 # Enabled (orange cloud) is 1. Disabled (grey cloud) is 0.
 cf_service_mode: 1
 
-# If set to 'true', prints a message only when the record changes or when
+# If set to true, prints a message only when the record changes or when
 # there's an error.  If set to 'false', prints a message every time even if
 # the record didn't change.
-quiet: 'false'
+quiet: false
 
 # If set to true then we call the ec2metadata service for the instance
 # public ip address rather than an external service.
 aws_use_ec2metadata: false
+
+# If set to true dig will be used to fetch the public IP which is better
+# but not available on all systems.
+use_dig: false


### PR DESCRIPTION
Now this should work, you can directly set your preferences through the config file (use_dig: true|false), false by default.
I tested it on both Linux and Windows and it seems working.