### PR TITLE
Add requirements install via pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ You'll need a python interpreter and the following libraries:
  - [Requests](http://docs.python-requests.org/en/latest/) (`pip install
    requests`)
 
+You can install them with `pip` :
+
+	pip install -r requirements.txt
+
 Usage
 -----
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pyyaml>=3.12
+requests>=2.11.1


### PR DESCRIPTION
This makes installation a tad easier, and allows to pin specific versions in the future.

Tested with the current versions. Most likely works with older releases of the dependencies too.